### PR TITLE
feat: better status parser

### DIFF
--- a/pymanga/parsers/series_parsers.py
+++ b/pymanga/parsers/series_parsers.py
@@ -212,7 +212,7 @@ def _parse_col_1(col,manga):
         manga['latest_releases'].append(release)
 
 
-    manga['status'] = str(contents[6].string).replace('\n','')
+    manga['status'] = contents[6].get_text(separator='!@#').replace('\n','').split('!@#')
     if str(contents[7].string).replace('\n','') == 'No':
         manga['completely_scanlated'] = False
     else:


### PR DESCRIPTION
The current implement can sometimes return 'None', while actually the status have multiple lines.

For example, this [manga](https://www.mangaupdates.com/series.html?id=164539) cause py-manga fail to parse status. This is due to difference between `.string` and `.get_text()` in bs4. And the new implementation can correctly parse status, and moreover divides each into a list. 

