### PR TITLE
Fix and new feature

### DIFF
--- a/pymanga/api.py
+++ b/pymanga/api.py
@@ -2,7 +2,7 @@ import requests
 from bs4 import BeautifulSoup
 import urllib.parse as urlparse
 import re
-import os
+import time
 from .parsers import search_parsers, series_parsers, releases_parsers, adv_search_parser, group_parsers
 
 
@@ -174,7 +174,7 @@ def advanced_search(params, all_pages=False, page=1):
             r, _ = advanced_search(params, page=p)
             results = results + r
 
-        os.sleep(1)  # be polite!
+        time.sleep(1)  # be polite!
 
     return (results, pages)
 

--- a/pymanga/api.py
+++ b/pymanga/api.py
@@ -3,7 +3,7 @@ from bs4 import BeautifulSoup
 import urllib.parse as urlparse
 import re
 import os
-from .parsers import search_parsers, series_parsers, releases_parsers, adv_search_parser
+from .parsers import search_parsers, series_parsers, releases_parsers, adv_search_parser, group_parsers
 
 
 def search(query):
@@ -353,7 +353,6 @@ def series(id, description_format="markdown"):
     )
     return series_parsers.parse_series(content, description_format=description_format)
 
-
 def releases(id):
     """
     Get latest releases of a manga
@@ -404,3 +403,54 @@ def releases(id):
     except:
         releases = []
     return releases
+
+def group(id):
+    """
+    Get group info from mangaupdates.
+
+    Parameters
+    ----------
+    id : str
+        Series id.
+
+    Returns
+    -------
+    group : dict
+        group information.
+        ::
+
+            {
+                'name': 'Group name',
+                'IRC': 'IRC link',
+                'website': 'link',
+                'forum': 'forum link, usually mangadex',
+                'discord': 'link to discord server',
+                'twitter': 'link to twitter',
+                'facebook': 'link to facebook',
+                'release_frequency': 'release frequency',
+                'number_of_release': 'number of scanlated releases',
+                'active': 'the status of the group',
+                'total_series' : 'number of scanlated series',
+                'genres': 'genre count of scanlated series',
+                'categiries': 'category count of scanlated series',
+                'notes': 'useful information, like previous name'
+                'series': [
+                    {
+                        'id': 'series id',
+                        'name': 'series name',
+                    }
+                ]
+                'releases': [
+                    # TODO
+                ]
+            }
+
+    """
+    r = requests.get("https://mangaupdates.com/groups.html", params={"id": id})
+    soup = BeautifulSoup(r.text, "html.parser")
+    contents = (
+        soup.find("div", id="main_content")
+        .find("div", class_="p-2", recursive=False)
+        .find_all('div', class_='table_content')
+    )
+    return group_parsers.parse_group(contents)

--- a/pymanga/parsers/adv_search_parser.py
+++ b/pymanga/parsers/adv_search_parser.py
@@ -52,9 +52,9 @@ def parse_results(soup):
 
         results.append(
             {
-                "name": info[0].a.u.b.get_text(),
+                "name": info[0].find('a',dict(href=True)).u.b.get_text(),
                 "id": info[0]
-                .a["href"]
+                .find('a',dict(href=True))["href"]
                 .replace("https://www.mangaupdates.com/series.html?id=", ""),
                 "genres": info[1].a["title"].split(", "),
                 "summary": info[2].get_text(),

--- a/pymanga/parsers/group_parsers.py
+++ b/pymanga/parsers/group_parsers.py
@@ -11,6 +11,8 @@ def parse_count(text):
     result = dict()
     categories = text.split(',')
     for cat in categories:
+        if len(cat)==0:
+            continue
         parsed = re.search('([^()]+)\(([^()]+)\)', cat)
         name = parsed.group(1).strip()
         count = parsed.group(2).strip()

--- a/pymanga/parsers/group_parsers.py
+++ b/pymanga/parsers/group_parsers.py
@@ -69,12 +69,15 @@ def parse_group(contents, note_format="markdown"):
 
     # info 
     info_tags = info.find('div', class_='row').find_all("div", class_="col-6", recursive=False)
-    if note_format=='markdown':
-        notes = markdownify(str(info_tags[27]))
-    elif note_format=='raw':
-        notes = str(info_tags[27])
-    else:
-        notes = info_tags[27].get_text()
+    try:
+        if note_format=='markdown':
+            notes = markdownify(str(info_tags[27]))
+        elif note_format=='raw':
+            notes = str(info_tags[27])
+        else:
+            notes = info_tags[27].get_text()
+    except IndexError:
+        notes = ''
 
     group = dict(
         name=info_tags[1].get_text(),

--- a/pymanga/parsers/group_parsers.py
+++ b/pymanga/parsers/group_parsers.py
@@ -1,0 +1,107 @@
+from markdownify import markdownify
+import re
+
+def extract_href_or_text(content):
+    if content.find('a') is not None:
+        return content.find('a').get('href')
+    else:
+        return content.get_text()
+
+def parse_count(text):
+    result = dict()
+    categories = text.split(',')
+    for cat in categories:
+        parsed = re.search('([^()]+)\(([^()]+)\)', cat)
+        name = parsed.group(1).strip()
+        count = parsed.group(2).strip()
+        result[name] = int(count)
+    return result
+
+
+def parse_group(contents, note_format="markdown"):
+    """
+    Parse group info from mangaupdates.
+
+    Parameters
+    ----------
+    content : BeautifulSoup
+        BeautifulSoup object of the group page content.
+    note_format : str, optional
+        Format to transform the note into. can be 'plain', 'raw' or 'markdown'. defaults to 'markdown'.
+
+    Returns
+    -------
+    series : dict
+        Series information.
+        ::
+
+            {
+                'name': 'Group name',
+                'IRC': 'IRC link',
+                'website': 'link',
+                'forum': 'forum link, usually mangadex',
+                'discord': 'link to discord server',
+                'twitter': 'link to twitter',
+                'facebook': 'link to facebook',
+                'release_frequency': 'release frequency',
+                'number_of_release': 'number of scanlated releases',
+                'active': 'the status of the group',
+                'total_series' : 'number of scanlated series',
+                'genres': 'genre count of scanlated series',
+                'categiries': 'category count of scanlated series',
+                'notes': 'useful information, like previous name'
+                'series': [
+                    {
+                        'id': 'series id',
+                        'name': 'series name',
+                    }
+                ]
+                'releases': [
+                    # TODO
+                ]
+            }
+
+    """
+    info = contents[0]
+    # TODO
+    releases = contents[1]
+    series = contents[2]
+
+    # info 
+    info_tags = info.find('div', class_='row').find_all("div", class_="col-6", recursive=False)
+    if note_format=='markdown':
+        notes = markdownify(str(info_tags[27]))
+    elif note_format=='raw':
+        notes = str(info_tags[27])
+    else:
+        notes = info_tags[27].get_text()
+
+    group = dict(
+        name=info_tags[1].get_text(),
+        IRC=extract_href_or_text(info_tags[3]),
+        website=extract_href_or_text(info_tags[5]),
+        forum=extract_href_or_text(info_tags[7]),
+        discord=extract_href_or_text(info_tags[9]),
+        twitter=extract_href_or_text(info_tags[11]),
+        facebook=extract_href_or_text(info_tags[13]),
+        release_frequency=info_tags[15].get_text(),
+        number_of_release=info_tags[17].get_text(),
+        active=info_tags[19].get_text(),
+        total_series=info_tags[21].get_text(),
+        genres=parse_count(info_tags[23].get_text()),
+        categiries=parse_count(info_tags[25].get_text()),
+        notes=notes,
+    )
+
+    series_parsed = []
+    for s in series.find_all('div', class_='col-6'):
+        if s.find('a') is None:
+            continue
+        id = s.find('a').get('href').replace('https://www.mangaupdates.com/series.html?id=', '')
+        name = s.get_text()
+        series_parsed.append(dict(id=id, name=name))
+    group['series'] = series_parsed
+
+    group['releases'] = []
+
+    return group

--- a/pymanga/parsers/series_parsers.py
+++ b/pymanga/parsers/series_parsers.py
@@ -362,16 +362,30 @@ def _parse_col_2(col, manga):
 
     manga["artists"] = []
     for artist in contents[6].find_all("a"):
-        manga["artists"].append(
-            {
-                "name": artist.get_text(),
-                "id": artist.get("href", "").replace(
-                    "https://www.mangaupdates.com/authors.html?id=", ""
-                )
-                if contents[6].a
-                else "N/A",
-            }
-        )
+        query = urllib.parse.parse_qs(urllib.parse.urlparse(artist.get('href', '')).query)
+        if 'id' in query.keys():
+            manga["artists"].append(
+                {
+                    "name": artist.get_text(),
+                    "id": query['id'][0]
+                    if contents[6].a
+                    else "N/A",
+                }
+            )
+        elif 'author' in query.keys():
+            manga["artists"].append(
+                {
+                    "name": query['author'][0],
+                    "id": "N/A",
+                }
+            )
+        else:
+            manga["artists"].append(
+                {
+                    "name": artist.get_text(),
+                    "id": "N/A",
+                }
+            )
 
     manga["year"] = contents[7].get_text().replace("\n", "")
 

--- a/pymanga/parsers/series_parsers.py
+++ b/pymanga/parsers/series_parsers.py
@@ -1,5 +1,5 @@
 import markdownify, html2text
-from bs4 import Comment
+from bs4 import Comment, BeautifulSoup
 import re
 import urllib
 
@@ -256,8 +256,9 @@ def _parse_col_1(col, manga, description_format):
 
         manga["latest_releases"].append(release)
 
+    [m.unwrap() for t in ['b', 'i', 'u'] for m in contents[6].findAll(t)]
     manga["status"] = (
-        contents[6].get_text(separator="!@#").replace("\n", "").split("!@#")
+        BeautifulSoup(repr(contents[6]), "html.parser").get_text(separator="!@#").replace("\n", "").split("!@#")
     )
     if str(contents[7].string).replace("\n", "") == "No":
         manga["completely_scanlated"] = False

--- a/pymanga/parsers/series_parsers.py
+++ b/pymanga/parsers/series_parsers.py
@@ -1,6 +1,7 @@
 import markdownify, html2text
 from bs4 import Comment
 import re
+import urllib
 
 def parse_series(content, description_format="markdown"):
     """
@@ -334,16 +335,30 @@ def _parse_col_2(col, manga):
 
     manga["authors"] = []
     for author in contents[5].find_all("a"):
-        manga["authors"].append(
-            {
-                "name": author.get_text(),
-                "id": author.get("href", "").replace(
-                    "https://www.mangaupdates.com/authors.html?id=", ""
-                )
-                if contents[5].a
-                else "N/A",
-            }
-        )
+        query = urllib.parse.parse_qs(urllib.parse.urlparse(author.get('href', '')).query)
+        if 'id' in query.keys():
+            manga["authors"].append(
+                {
+                    "name": author.get_text(),
+                    "id": query['id'][0]
+                    if contents[5].a
+                    else "N/A",
+                }
+            )
+        elif 'author' in query.keys():
+            manga["authors"].append(
+                {
+                    "name": query['author'][0],
+                    "id": "N/A",
+                }
+            )
+        else:
+            manga["authors"].append(
+                {
+                    "name": author.get_text(),
+                    "id": "N/A",
+                }
+            )
 
     manga["artists"] = []
     for artist in contents[6].find_all("a"):

--- a/pymanga/parsers/series_parsers.py
+++ b/pymanga/parsers/series_parsers.py
@@ -2,7 +2,6 @@ import markdownify, html2text
 from bs4 import Comment
 import re
 
-
 def parse_series(content, description_format="markdown"):
     """
     Parse series info from mangaupdates.
@@ -233,6 +232,8 @@ def _parse_col_1(col, manga, description_format):
     dates = contents[5].find_all("span")
 
     for i in range(0, len(dates)):
+        if len(numbers) != len(groups):
+            continue
         release = {
             "group": {
                 "name": groups[i].get_text(),


### PR DESCRIPTION
Fix: 
- use `time.sleep` instead of invalid `os.sleep`
- avoid empty author or artist name return `Add` 
- avoid line break for b, u, i tags
- require `href` attribute when parsing name and id in adv search, since the current mangaupdates contains two `a` tags in `info[0]`

Features:
- group parser
